### PR TITLE
MNT Add readme and .gitattributes files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/client/src
+/tests export-ignore
+/.tx export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.github export-ignore
+/*.dist export-ignore
+/.editorconfig export-ignore

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+## Silverstripe HTMLEditor TinyMCE
+
+[![CI](https://github.com/silverstripe/silverstripe-htmleditor-tinymce/actions/workflows/ci.yml/badge.svg)](https://github.com/silverstripe/silverstripe-htmleditor-tinymce/actions/workflows/ci.yml)
+[![Silverstripe supported module](https://img.shields.io/badge/silverstripe-supported-0071C4.svg)](https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/)
+
+## Overview
+
+Provides a TinyMCE 6 HTML editor for Silverstripe CMS.
+
+## Installation
+
+```sh
+composer require silverstripe/htmleditor-tinymce
+```
+
+## Documentation
+
+See [docs.silverstripe.org](https://docs.silverstripe.org/en/optional_features/htmleditor-tinymce/)


### PR DESCRIPTION
Realised the `.gitattributes` file was also missing.

## Issue
- https://github.com/silverstripe/silverstripe-htmleditor-tinymce/issues/7