### PR TITLE
DEP Remove alpha conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,6 @@
         "squizlabs/php_codesniffer": "^3",
         "phpstan/extension-installer": "^1.3"
     },
-    "conflict": {
-        "silverstripe/installer": "6.0.0-alpha1"
-    },
     "autoload": {
         "psr-4": {
             "SilverStripe\\TinyMCE\\": "src/",


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-htmleditor-tinymce/issues/23

This was the only module in sink which still had an alpha conflict