### PR TITLE
ENH Add help plugin by default for accessibility.

### DIFF
--- a/src/TinyMCEConfig.php
+++ b/src/TinyMCEConfig.php
@@ -340,6 +340,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
         'searchreplace' => null,
         'visualblocks' => null,
         'wordcount' => null,
+        'help' => null,
     ];
 
     /**

--- a/tests/php/TinyMCEConfigTest.php
+++ b/tests/php/TinyMCEConfigTest.php
@@ -153,7 +153,8 @@ class TinyMCEConfigTest extends SapphireTest
             'autolink',
             'searchreplace',
             'visualblocks',
-            'wordcount'
+            'wordcount',
+            'help'
         );
         $c->enablePlugins(
             [


### PR DESCRIPTION
The help plugin provides keyboard shortcuts and is required for screen-reader users to know what keys will let them access menus etc.

It also automatically adds a note to the footer that pressing `ALT+0` opens the help menu:

<img width="738" height="668" alt="image" src="https://github.com/user-attachments/assets/fc6c5ee3-7e9b-4ffe-80d5-6ddc9b6feab5" />

A message was _already_ being read to screen readers about pressing that key combination - though pressing it did nothing without the plugin.

## Issue

- https://github.com/silverstripe/silverstripe-htmleditor-tinymce/issues/25